### PR TITLE
fixing broken links in training dropdown

### DIFF
--- a/js/templates/nav.handlebars
+++ b/js/templates/nav.handlebars
@@ -13,7 +13,7 @@
             <li><a href="resources.html">Resources</a></li>
 			
 			<li class="shower">
-				<a href="http://owi.usgs.gov/R/training">Training</a>
+				<a href="http://owi.usgs.gov/R/training.html">Training</a>
 				<ul id="trainingDropdown">
 					<li><a href="training.html">Training Schedule</a></li>
 					
@@ -24,7 +24,7 @@
 					</li>
 					
 					<li>
-						<a href="http://owi.usgs.gov/R/training-curriculum/course-specific-links">
+						<a href="http://owi.usgs.gov/R/training-curriculum/course-specific-material">
 							Course Specific Materials
 						</a>
 					</li>
@@ -38,7 +38,7 @@
 			</li>
 			
 			<li class="mobileLinks">
-				<a href="http://owi.usgs.gov/R/training-curriculum/course-specific-links">
+				<a href="http://owi.usgs.gov/R/training-curriculum/course-specific-material">
 					Course Specific Materials
 					</a>
 			</li>


### PR DESCRIPTION
@mwernimont this is now updated based on what we fixed in training-curriculum. Sorry, you were probably copying the links I had in here, and I had them wrong